### PR TITLE
testing #181 + setup #47 + include theories in sphinx documentation. …

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-python_version >= 3.11
+python_version >= 3.10
 Sphinx
 sphinx-autodoc-typehints
 sphinx-exec-code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python_version >= 3.11
+python_version >= 3.10
 pyvis
 networkx
 unidecode


### PR DESCRIPTION
…readthedocs seem not to support python 3.11. make an attempt with 3.10 to support at the very least the match syntax.